### PR TITLE
`additional_bone_ids` is None when loading `.vrm` models

### DIFF
--- a/entities/vrm/VRMModel.gd
+++ b/entities/vrm/VRMModel.gd
@@ -90,6 +90,7 @@ static func _to_godot_quat(v: Quat) -> Quat:
 ###############################################################################
 
 func scan_mapped_bones() -> void:
+	.scan_mapped_bones()
 	for bone_name in additional_bones_to_pose_names:
 		if bone_name.to_lower() == "root":
 			additional_bones_to_pose_names.erase(bone_name)


### PR DESCRIPTION
**Issue:** When loading `.vrm` models `additional_bone_ids` is not initialized causing the program to crash on `BasicModel.gd Line 117 `.

**Proposed solution**: Call parent function `BasicModel.scan_mapped_bones()` from `VRMModel.scan_mapped_bones()`. This will enable `VRMModel.scan_mapped_bones()` to extend the original functionality of its parent while also setting `additional_bone_ids`.

**Additional Notes:** Thank you so much for all your great work on this project! Its truly great to see how well this project has come together!