### PR TITLE
New Feature: Set default model

### DIFF
--- a/screens/MainScreen.gd
+++ b/screens/MainScreen.gd
@@ -21,7 +21,7 @@ func _ready() -> void:
 	
 	AppManager.connect("file_to_load_changed", self, "_on_file_to_load_changed")
 
-	AppManager.set_file_to_load("res://entities/basic-models/Duck.tscn")
+	AppManager.set_file_to_load(AppManager.get_default_model_path())
 
 func _input(event: InputEvent) -> void:
 	if(event.is_action_pressed("ui_cancel") and OS.is_debug_build()):

--- a/screens/gui/model-view/ModelView.gd
+++ b/screens/gui/model-view/ModelView.gd
@@ -32,6 +32,14 @@ func _on_load_model_button_pressed() -> void:
 	yield(model_selection_popup, "file_selected")
 	model_selection_popup.queue_free()
 
+func _set_model_default_button_pressed() -> void:
+	AppManager.set_model_default()
+
+func _on_default_model_set() -> void:
+	var default_button: Button = right_container.outer.get_node_or_null("set_model_default_button")
+	if default_button:
+		default_button.disabled = true
+
 ###############################################################################
 # Private functions                                                           #
 ###############################################################################
@@ -106,7 +114,25 @@ func _setup_right(config: Dictionary) -> void:
 				initial_properties[c.name] = c.get_value()
 			elif c is InputLabel:
 				initial_properties[c.name] = c.get_value()
-	
+
+	if not right_container.outer.get_node_or_null("set_model_default_button"):
+		var set_model_default_button: Button = Button.new()
+		set_model_default_button.name = "set_model_default_button"
+		set_model_default_button.text = "Set as default"
+		set_model_default_button.size_flags_vertical = SIZE_EXPAND_FILL
+		set_model_default_button.size_flags_vertical = SIZE_EXPAND_FILL
+		set_model_default_button.size_flags_stretch_ratio = 0.1
+		set_model_default_button.focus_mode = FOCUS_NONE
+		set_model_default_button.connect("pressed", self, "_set_model_default_button_pressed")
+		right_container.add_to_outer(set_model_default_button)
+
+	var tempButton: Button = right_container.outer.get_node_or_null("set_model_default_button")
+	# Toggle button disabled property if model is or is not default
+	if AppManager.is_current_model_default():
+		tempButton.disabled = true
+	else:
+		tempButton.disabled = false
+
 	if not right_container.outer.get_node_or_null("load_model_button"):
 		var load_model_button: Button = Button.new()
 		load_model_button.name = "load_model_button"

--- a/screens/gui/model-view/ModelView.gd
+++ b/screens/gui/model-view/ModelView.gd
@@ -121,7 +121,6 @@ func _setup_right(config: Dictionary) -> void:
 		set_model_default_button.name = "set_model_default_button"
 		set_model_default_button.text = "Set as default"
 		set_model_default_button.size_flags_vertical = SIZE_EXPAND_FILL
-		set_model_default_button.size_flags_vertical = SIZE_EXPAND_FILL
 		set_model_default_button.size_flags_stretch_ratio = 0.1
 		set_model_default_button.focus_mode = FOCUS_NONE
 		set_model_default_button.connect("pressed", self, "_set_model_default_button_pressed")

--- a/screens/gui/model-view/ModelView.gd
+++ b/screens/gui/model-view/ModelView.gd
@@ -13,6 +13,7 @@ var mapped_bones: Array = []
 ###############################################################################
 
 func _ready() -> void:
+	AppManager.connect("default_model_set", self, "_on_default_model_set")
 	_setup()
 
 ###############################################################################


### PR DESCRIPTION
**Proposal:** When using `openfacesee-gd` as a regular user, loading your model(s) every single time you start the application is  tedious. To improve the quality of life for users we should consider adding a button (or other UI element) that allows the user to save the current model as their "default model". This change will save the the `app_config` and persist through application starts.

**Summary of Changes:**

- Added a new button to `MainView.gd` labeled `Set as default`
  - If the model is already saved as default, the button will be disabled
- Added new app_config entry to store default model path: `["settings"]["default_model"] 
- Added public member `AppManager.set_model_default()` to enable setting and saving the default model
- Added public member `AppManager.get_current_model_path()` to get the current active model (can be different then default)
- Added public member `AppManager.is_current_model_default()` to enable checking if the current active model is the default (used for making "Set as default" button enabled/disabled
- Added `export/.gitkeep` so app_config exists by default (enabling saving app_config)

Please let me know if you have any feedback or require test coverage for this feature.

Thanks & Keep up the great work as always!