### PR TITLE
Fix running facetracker.py on linux

### DIFF
--- a/utils/OpenSeeGD.gd
+++ b/utils/OpenSeeGD.gd
@@ -237,8 +237,6 @@ func _on_start_tracker() -> void:
 			"0",
 			"-F",
 			face_tracker_fps,
-			"-D",
-			"-1",
 			"-v",
 			"0",
 			"-s",
@@ -262,6 +260,7 @@ func _on_start_tracker() -> void:
 			var pid: int = -1
 			match OS.get_name().to_lower():
 				"windows":
+					face_tracker_options.append_array(["-D", "-1"])
 					var exe_path: String = "%s%s" % [OS.get_executable_path().get_base_dir(), "/OpenSeeFaceFolder/OpenSeeFace/facetracker.exe"]
 					if OS.is_debug_build():
 						exe_path = "%s%s" % [ProjectSettings.globalize_path("res://export"), "/OpenSeeFaceFolder/OpenSeeFace/facetracker.exe"]
@@ -288,7 +287,7 @@ func _on_start_tracker() -> void:
 						AppManager.log_message("Unable to find python executable")
 						return
 					
-					pid = OS.execute("%s" % [python_alias], face_tracker_options,
+					pid = OS.execute("%s" % [python_alias], modified_options,
 							false, [], true)
 				_:
 					AppManager.log_message("Unhandled os type %s" % OS.get_name(), true)


### PR DESCRIPTION
This should fix #40 once [this pull request](https://github.com/emilianavt/OpenSeeFace/pull/31) is merged with OpenSeeFace. I've tested this on Linux and it seems to work fine, and it should be the same for Windows, though I don't have a Windows machine so i haven't been able to confirm