### PR TITLE
make tracker launch more configurable

### DIFF
--- a/resources/gui/tracking.xml
+++ b/resources/gui/tracking.xml
@@ -23,7 +23,10 @@
         <label name="Tracking Options"/>
         <drop_down name="Camera Select" data="camera_select" event="camera_select" setup="setup_cameras"/>
         <input name="Tracker FPS" data="tracker_fps" event="tracker_fps" type="integer"/>
-        <button name="Start Tracker" event="start_tracker" label_updatable="true"/>
+        <toggle name="Should launch tracker" data="tracker_should_launch" event="tracker_should_launch"/>
+        <input name="Tracker Address" data="tracker_address" event="tracker_address" type="string"/>
+        <input name="Tracker Port" data="tracker_port" event="tracker_port" type="integer"/>
+        <button name="Start Tracker" event="toggle_tracker" label_updatable="true"/>
         <!-- TODO this is bad, should refactor into a list -->
         <label name="Blend Shapes"/>
         <drop_down name="Blend Shapes" event="blend_shapes" setup="setup_blend_shapes"/>

--- a/utils/AppManager.gd
+++ b/utils/AppManager.gd
@@ -50,8 +50,7 @@ func _process(delta: float) -> void:
 ###############################################################################
 
 func _on_tree_exiting() -> void:
-	if OpenSeeGd.is_listening:
-		OpenSeeGd.stop_receiver()
+	OpenSeeGd.stop_receiver()
 
 	cm.save_config()
 	

--- a/utils/ConfigManager.gd
+++ b/utils/ConfigManager.gd
@@ -108,7 +108,10 @@ class ConfigData:
 
 	var blink_threshold: float = 0.2
 
+	var tracker_should_launch: bool = true
 	var tracker_fps: int = 12
+	var tracker_address: String = "127.0.0.1"
+	var tracker_port: int = 11573
 
 	###
 	# Feature
@@ -285,6 +288,11 @@ func _init() -> void:
 
 	AppManager.sb.connect("camera_select", self, "_on_camera_select")
 
+	AppManager.sb.connect("tracker_should_launch", self, "_on_tracker_should_launch")
+	AppManager.sb.connect("tracker_fps", self, "_on_tracker_fps")
+	AppManager.sb.connect("tracker_address", self, "_on_tracker_address")
+	AppManager.sb.connect("tracker_port", self, "_on_tracker_port")
+
 	# Features
 
 	AppManager.sb.connect("main_light", self, "_on_main_light")
@@ -339,6 +347,18 @@ func _on_gaze_strength(value: float) -> void:
 
 func _on_blink_threshold(value: float) -> void:
 	current_model_config.blink_threshold = value
+
+func _on_tracker_should_launch(value: bool) -> void:
+	current_model_config.tracker_should_launch = value
+	
+func _on_tracker_fps(value: int) -> void:
+	current_model_config.tracker_fps = value
+
+func _on_tracker_address(value: String) -> void:
+	current_model_config.tracker_address = value
+
+func _on_tracker_port(value: int) -> void:
+	current_model_config.tracker_port = value
 
 func _on_camera_select(camera_index: String) -> void:
 	metadata_config.camera_index = camera_index

--- a/utils/SignalBroadcaster.gd
+++ b/utils/SignalBroadcaster.gd
@@ -96,9 +96,21 @@ signal tracker_fps(value)
 func broadcast_tracker_fps(value: int) -> void:
 	emit_signal("tracker_fps", value)
 
-signal start_tracker()
-func broadcast_start_tracker() -> void:
-	emit_signal("start_tracker")
+signal tracker_should_launch(value)
+func broadcast_tracker_should_launch(value: bool) -> void:
+	emit_signal("tracker_should_launch", value)
+
+signal tracker_address(value)
+func broadcast_tracker_address(value: String) -> void:
+	emit_signal("tracker_address", value)
+
+signal tracker_port(value)
+func broadcast_tracker_port(value: int) -> void:
+	emit_signal("tracker_port", value)
+	
+signal toggle_tracker()
+func broadcast_toggle_tracker() -> void:
+	emit_signal("toggle_tracker")
 
 # TODO started in Tracking.gd, to VRMModel, this isn't great
 signal blend_shapes(value)


### PR DESCRIPTION
- this adds configurability of the tracker address and port, as well as an option for launching the tracker at all from the application, for users who prefer to launch it themselves manually (in case the launch of the tracker is not desired, only the receiver thread is started)
- also the previously configurable FPS is now saved when changed (this was probably just a bug?)
- renames the `start_tracker` things to `toggle_tracker` to better reflect the actual behavior

Should also make the `is_listening` (now `is_tracking`) more consistent (there were some cases in which it was still set to true, even tho the tracker was not launched, if i read it correctly).

Some things that may be not ideal:
- FPS input should probably be disabled/not shown in case 'should launch tracker' is OFF, but unfortunately I don't know how to do that yet ^^"
- address and port could get some basic checks for valid looking value

I hope there is not something horribly wrong with the PR :D 
If there are any kind of tests I can run, please let me know!

