### PR TITLE
automatically store last model and prop search paths from file dialogs

### DIFF
--- a/resources/gui/app-settings.xml
+++ b/resources/gui/app-settings.xml
@@ -1,6 +1,5 @@
 <view name="App Settings" script="AppSettings.gd">
     <left>
-        <input name="Default Search Path" data="default_search_path" event="default_search_path" type="string"/>
         <label name="Antialiasing"/>
         <toggle name="Use Transparent Background" data="use_transparent_background" event="use_transparent_background"/>
         <toggle name="Use FXAA" data="use_fxaa" event="use_fxaa"/>

--- a/screens/gui/Gui.gd
+++ b/screens/gui/Gui.gd
@@ -299,7 +299,7 @@ func _on_load_model() -> void:
 
 	yield(get_tree(), "idle_frame")
 
-	var load_path: String = AppManager.cm.metadata_config.default_search_path
+	var load_path: String = AppManager.cm.metadata_config.default_model_search_path
 	if not load_path.ends_with("/"):
 		load_path += "/"
 	popup.current_dir = load_path
@@ -307,6 +307,9 @@ func _on_load_model() -> void:
 
 	# TODO this might be a memory leak if you open up many popups but don't select a model
 	yield(popup, "file_selected")
+	
+	AppManager.sb.broadcast_default_model_search_path(popup.file)
+	AppManager.cm.save_config()
 
 	_cleanup_props()
 
@@ -348,14 +351,17 @@ func _on_add_custom_prop() -> void:
 
 	yield(get_tree(), "idle_frame")
 
-	var load_path: String = AppManager.cm.metadata_config.default_search_path
+	var load_path: String = AppManager.cm.metadata_config.default_prop_search_path
 	if not load_path.ends_with("/"):
 		load_path += "/"
 	popup.current_dir = load_path
 	popup.current_path = load_path
 
 	yield(popup, "file_selected")
-
+	
+	AppManager.sb.broadcast_default_prop_search_path(popup.file)
+	AppManager.cm.save_config()
+	
 	var prop_name: String = popup.file.get_file() \
 		.trim_suffix(popup.file.get_extension()).trim_suffix(".")
 	# Set distinct prop name so we don't accidentally override existing props

--- a/utils/SignalBroadcaster.gd
+++ b/utils/SignalBroadcaster.gd
@@ -206,9 +206,13 @@ func broadcast_preset_loaded() -> void:
 
 # App settings
 
-signal default_search_path(value)
-func broadcast_default_search_path(value: String) -> void:
-	emit_signal("default_search_path", value)
+signal default_model_search_path(value)
+func broadcast_default_model_search_path(value: String) -> void:
+	emit_signal("default_model_search_path", value)
+
+signal default_prop_search_path(value)
+func broadcast_default_prop_search_path(value: String) -> void:
+	emit_signal("default_prop_search_path", value)
 
 signal view_licenses()
 func broadcast_view_licenses() -> void:


### PR DESCRIPTION
removes the option to set a default search path in favor of storing the last search path automatically
there is a different setting stored for the prop loading dialog and the model loading dialog, because i can imagine that those would be stored in different folders and then it would be inconvenient to have to switch around when loading either

im not quite sure if i have to call `AppManager.cm.save_config()` but there is some async saving going on (havent looked at it in detail yet) and i wanted to make sure that after selecting this is reflected right away in the config 

if this is not desired at all feel free to decline the pr ^^ I just find it more convenient to start in the last folder that i loaded something from, instead of having to configure a search path.