### PR TITLE
fix fallback to default demo model

### DIFF
--- a/screens/ModelDisplayScreen.gd
+++ b/screens/ModelDisplayScreen.gd
@@ -238,8 +238,15 @@ func _try_load_model(file_path):
 		"vrm":
 			AppManager.log_message("Loading VRM file.")
 			var vrm_loader = VrmLoader.new()
+			# TODO: this needs to be futher looked at, as it seems like a hack
+			# vrm_meta needs to be read, stored in a var, and then AFTER
+			# set_script it needs to be set again, otherwise it somehow 
+			# isnt there when the script runs
+			var vrm_meta
 			model = vrm_loader.import_scene(file_path, 1, 1000)
+			vrm_meta = model.vrm_meta
 			model.set_script(load(VRM_MODEL_SCRIPT_PATH))
+			model.vrm_meta = vrm_meta
 			model.transform = model.transform.rotated(Vector3.UP, PI)
 			AppManager.cm.current_model_config.model_transform = model.transform
 			translation_adjustment = Vector3(-1, -1, -1)

--- a/utils/ConfigManager.gd
+++ b/utils/ConfigManager.gd
@@ -1,8 +1,6 @@
 class_name ConfigManager
 extends Reference
 
-const DEMO_MODEL_PATH: String = "res://entities/basic-models/Duck.tscn"
-
 const CONFIG_FORMAT: String = "%s/%s.json"
 
 const METADATA_NAME: String = "app-config.json"
@@ -461,9 +459,6 @@ func setup() -> void:
 		metadata_file.store_string(metadata_config.get_as_json())
 
 		metadata_file.close()
-	
-	if metadata_config.default_model_to_load_path.empty():
-		metadata_config.default_model_to_load_path = DEMO_MODEL_PATH
 
 	has_loaded_metadata = true
 


### PR DESCRIPTION
fixes #57

- removes preload of duck scene (not required, right? usually ppl will use their own models anyway)
- when the model cant be loaded (only file missing check is currently in place) then the default model (duck) is loaded
- removed overwriting of the config with the duck scene, as there is a fallback in place anyway and if the removed file gets moved back, it should still be the one that is loaded by default