### PR TITLE
improve behavior on tracker start

### DIFF
--- a/utils/OpenSeeGD.gd
+++ b/utils/OpenSeeGD.gd
@@ -252,6 +252,7 @@ func _on_toggle_tracker() -> void:
 			AppManager.main.model_display_screen.tracking_started()
 		else:
 			AppManager.sb.broadcast_update_label_text("Start Tracker", RUN_FACE_TRACKER_TEXT)
+			AppManager.main.model_display_screen.tracking_stopped()
 			
 
 ###############################################################################


### PR DESCRIPTION
Prior to this, there was a 3 seconds timer during which the model would weirdly be rotated or otherwise transformed (only on first start of tracker) Then after the 3 seconds, you had to be in the right position kind of, to make the tracking work right (i didnt know about the ability to press ENTER to get offsets read anew, I didnt really understand what that part in the readme meant, but now i do^^)
The model got strangely rotated on first 'Start Tracker' since starting the program, because the default value of stored_offsets was not null, but actually a StoredOffsets object, so the check in `_physics_process` to prevent tracking didnt work (i think). It would always try to read data from openseegd, and as soon as there was data, calculate some offsets from that default StoredOffsets object, and only after 3 seconds adjust itself.

This pr makes it so that as soon as there is data, the offsets get calculated and tracking starts.

There is one change to the previous behavior introduced by this: when stopping and starting the tracker, the offsets are re-read, where before they would be stored during tracker restarts. If that behavior is desired, then in `tracking_stopped` i can remove the `stored_offsets = null` line, and it will behave as before (just without the 3 seconds delay and weird transformy thingy).