### PR TITLE
dont quit program when hitting ESC while file browser is open

### DIFF
--- a/screens/MainScreen.gd
+++ b/screens/MainScreen.gd
@@ -39,7 +39,7 @@ func _ready() -> void:
 
 	AppManager.cm.metadata_config.apply_rendering_changes(get_viewport())
 
-func _input(event: InputEvent) -> void:
+func _unhandled_input(event: InputEvent) -> void:
 	if(event.is_action_pressed("ui_cancel") and OS.is_debug_build()):
 		get_tree().quit()
 


### PR DESCRIPTION
maybe it is intended like it is now (cuz its only for debug build)
but when i m in a file select dialog and hit esc, i expect only the dialog to close
with `_input` this will bubble through and the whole program will close, so changed it to `_unhandled_input`
i assume this would still close the tool in almost all other situations like expected

unfortunately i cant create a build yet for linux, so i start the tool from the IDE always, so it was a bit annoying ^^"