### PR TITLE
Add support for python version checking on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All models should work as long as they are in `.glb` or `.vrm` format. `.gltf` h
 1. Download Godot 3.4
 2. Clone this project and load it in the editor
 3. Clone the [OpenSeeFace](https://github.com/emilianavt/OpenSeeFace) face tracker
-4. If on Windows, move the `OpenSeeFace` repo into `$PROJECT_ROOT/export/OpenSeeFaceFolder`. If on Linux, run the facetracker via Python
+4. If on Windows, move the `OpenSeeFace` repo into `$PROJECT_ROOT/export/OpenSeeFaceFolder`. If on Linux, run the facetracker via Python (currently only versions below 3.10 are supported)
 5. Run the project from the editor
 6. In the program, when starting face tracking and if you are running OpenSeeFace via Python, disable the option to have the program start the face tracker
 7. Start face tracking

--- a/resources/licenses/extra-credits.txt
+++ b/resources/licenses/extra-credits.txt
@@ -6,3 +6,6 @@ Cappy Ishihara (@CappyIshihara on Twitter)
 
 Testing and Bug Reports
 Rogue Ren (@ItsRogueRen on Twitter)
+
+Python version checking on Linux
+ByteDream (@bytedream_dev on Twitter, ByteDream#4312 on Discord)

--- a/resources/scripts/create_venv.sh
+++ b/resources/scripts/create_venv.sh
@@ -4,11 +4,14 @@ set -e
 
 python_command=""
 
-if python_command="$(type -p python3)"; then
-    python_command="python3"
-elif python_command="$(type -p python)"; then
-    python_command="python"
-else
+for v in "" "3" "3.9" "3.8" "3.7" "3.6"; do
+    if "python$v" --version 2> /dev/null | grep -E -q "[2-3]\.[0-9]\."; then
+        python_command="python$v"
+        break
+    fi
+done
+
+if [ "$python_command" == "" ]; then
     exit 1
 fi
 

--- a/resources/scripts/run_osf_linux.sh
+++ b/resources/scripts/run_osf_linux.sh
@@ -4,11 +4,14 @@ set -e
 
 python_command=""
 
-if python_command="$(type -p python3)"; then
-    python_command="python3"
-elif python_command="$(type -p python)"; then
-    python_command="python"
-else
+for v in "" "3" "3.9" "3.8" "3.7" "3.6"; do
+    if "python$v" --version 2> /dev/null | grep -E -q "[2-3]\.[0-9]\."; then
+        python_command="python$v"
+        break
+    fi
+done
+
+if [ "$python_command" == "" ]; then
     exit 1
 fi
 


### PR DESCRIPTION
Since the `onnxruntime` library is currently only supported for python versions below `3.10`, this changes the linux scripts that need this library to check if the installed python version(s) are below `3.10` (#93).
The `README.md` now also contains a message that only version below `python3.10` are supported.

I  also added myself to `extra-credits.txt` lol.